### PR TITLE
Add std::hash implementation for char8_t

### DIFF
--- a/include/ext/__hash
+++ b/include/ext/__hash
@@ -69,6 +69,16 @@ template <> struct _LIBCPP_TEMPLATE_VIS hash<unsigned char>
     }
 };
 
+template <> struct _LIBCPP_TEMPLATE_VIS hash<unsigned char>
+ : public std::unary_function<char8_t, size_t>
+{
+    _LIBCPP_INLINE_VISIBILITY
+    size_t operator()(char8_t __c) const _NOEXCEPT
+    {
+        return __c;
+    }
+};
+
 template <> struct _LIBCPP_TEMPLATE_VIS hash<short>
  : public std::unary_function<short, size_t>
 {


### PR DESCRIPTION
See https://github.com/ClickHouse/ClickHouse/pull/9304

Note: gcc's libstdc++ already has this implementation. Surprisingly, libc++ does not.