### PR TITLE
Fix __sanitizer_annotate_contiguous_container() for gcc10 (extern "C" at the beginning)

### DIFF
--- a/include/__config
+++ b/include/__config
@@ -1095,7 +1095,7 @@ typedef unsigned int   char32_t;
 #endif
 
 #ifndef _LIBCPP_HAS_NO_ASAN
-_LIBCPP_FUNC_VIS extern "C" void __sanitizer_annotate_contiguous_container(
+extern "C" _LIBCPP_FUNC_VIS void __sanitizer_annotate_contiguous_container(
   const void *, const void *, const void *, const void *);
 #endif
 


### PR DESCRIPTION
gcc10 supports "extern C" only at the beginning, otherwise it parse it
differently:

    $ g++ -o /dev/null -c /tmp/test_extern.cpp
    /tmp/test_extern.cpp:1:52: error: expected unqualified-id before string constant
        1 | __attribute__ ((__visibility__("default"))) extern "C" int f…oo();
          |                                                    ^~~
    $ cat /tmp/test_extern.cpp
    __attribute__ ((__visibility__("default"))) extern "C" int foo();

    $ g++ -o /dev/null -c /tmp/test_extern.cpp
    $ cat /tmp/test_extern.cpp
    extern "C" __attribute__ ((__visibility__("default"))) int foo();