### PR TITLE
More flexible and portable init_priority support detection

### DIFF
--- a/include/__config
+++ b/include/__config
@@ -1435,10 +1435,14 @@ extern "C" _LIBCPP_FUNC_VIS void __sanitizer_annotate_contiguous_container(
 #define _LIBCPP_HAS_NO_FGETPOS_FSETPOS
 #endif
 
-#if __has_attribute(init_priority)
-# define _LIBCPP_INIT_PRIORITY_MAX __attribute__((init_priority(101)))
+#if !defined(_LIBCPP_INIT_PRIORITY_MAX) && defined(__has_attribute)
+#  if __has_attribute(init_priority)
+#    define _LIBCPP_INIT_PRIORITY_MAX __attribute__((init_priority(101)))
+#  else
+#    define _LIBCPP_INIT_PRIORITY_MAX
+#  endif
 #else
-# define _LIBCPP_INIT_PRIORITY_MAX
+#  define _LIBCPP_INIT_PRIORITY_MAX
 #endif
 
 #endif // __cplusplus


### PR DESCRIPTION
- Nested `__has_attribute(init_priority)` check is more portable: https://gcc.gnu.org/onlinedocs/cpp/_005f_005fhas_005fattribute.html
- Allowing pre-setting `_LIBCPP_INIT_PRIORITY_MAX` since vanilla GCC-10 in macOS still exit with error when `init_priority` is used, while reports `__has_attribute(init_priority)` as true.